### PR TITLE
Remove anchor with "javascript:;"

### DIFF
--- a/src/select2/match-multiple.tpl.html
+++ b/src/select2/match-multiple.tpl.html
@@ -8,6 +8,6 @@
       ng-class="{'select2-search-choice-focus':$selectMultiple.activeMatchIndex === $index, 'select2-locked':$select.isLocked(this, $index)}"
       ui-select-sort="$select.selected">
       <span uis-transclude-append></span>
-      <a href="javascript:;" class="ui-select-match-close select2-search-choice-close" ng-click="$selectMultiple.removeChoice($index)" tabindex="-1"></a>
+      <span class="ui-select-match-close select2-search-choice-close" ng-click="$selectMultiple.removeChoice($index)" tabindex="-1"></span>
   </li>
 </span>


### PR DESCRIPTION
I've not quite figured out what is causing this (maybe it's a new standard?) but anchor tags with javascript declarations seem to get pointed to "unsafe:javascript:;" which browsers handled in weird ways. Either way, this doesn't need to be an anchor.

<img width="1109" alt="screen shot 2018-07-16 at 5 43 08 pm" src="https://user-images.githubusercontent.com/1864534/42787387-e45cf644-891f-11e8-8d8a-03ed62cb53dd.png">
